### PR TITLE
perf(image): prioritize featured/hero images (preload + eager + fetchpriority=high)

### DIFF
--- a/layouts/partials/atoms/picture.html
+++ b/layouts/partials/atoms/picture.html
@@ -103,7 +103,11 @@
       srcset="{{ delimit $srcsetFallback ", " }}"
       sizes="{{ $sizesAttr }}"
       {{ with $alt }}alt="{{ . }}"{{ end }}
-      loading="lazy"
+      loading="{{ if eq $priority "high" }}
+        eager
+      {{ else }}
+        lazy
+      {{ end }}"
       decoding="async"
       {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
       width="{{ $width }}"
@@ -156,7 +160,11 @@
         srcset="{{ delimit $srcsetFallback ", " }}"
         sizes="{{ $sizesAttr }}"
         {{ with $alt }}alt="{{ . }}"{{ end }}
-        loading="lazy"
+        loading="{{ if eq $priority "high" }}
+          eager
+        {{ else }}
+          lazy
+        {{ end }}"
         decoding="async"
         {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
         width="{{ $width }}"
@@ -164,14 +172,24 @@
       />
     </picture>
   {{ else }}
-    {{/* No sibling base found; fall back to single source + plain img without dimensions */}}
+    {{/* No sibling base found; fall back to single source but keep dimensions to avoid CLS */}}
+    {{ $width = $res.Width }}
+    {{ $height = $res.Height }}
     <picture>
       <source type="image/{{ $type }}" srcset="{{ $res.RelPermalink }}" />
       <img
         src="{{ $res.RelPermalink }}"
         {{ with $alt }}alt="{{ . }}"{{ end }}
-        loading="lazy"
+        loading="{{ if eq $priority "high" }}
+          eager
+        {{ else }}
+          lazy
+        {{ end }}"
         decoding="async"
+        {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
+        {{ if and (gt $width 0) (gt $height 0) }}
+          width="{{ $width }}" height="{{ $height }}"
+        {{ end }}
       />
     </picture>
   {{ end }}
@@ -182,7 +200,11 @@
     <img
       src="{{ $res.RelPermalink }}"
       {{ with $alt }}alt="{{ . }}"{{ end }}
-      loading="lazy"
+      loading="{{ if eq $priority "high" }}
+        eager
+      {{ else }}
+        lazy
+      {{ end }}"
       decoding="async"
       {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
     />
@@ -226,7 +248,11 @@
         <img
           src="{{ $fallbackSrc }}"
           {{ with $alt }}alt="{{ . }}"{{ end }}
-          loading="lazy"
+          loading="{{ if eq $priority "high" }}
+            eager
+          {{ else }}
+            lazy
+          {{ end }}"
           decoding="async"
           {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
           {{ if and (gt $width 0) (gt $height 0) }}
@@ -245,7 +271,11 @@
       <img
         src="{{ $fallbackSrc }}"
         {{ with $alt }}alt="{{ . }}"{{ end }}
-        loading="lazy"
+        loading="{{ if eq $priority "high" }}
+          eager
+        {{ else }}
+          lazy
+        {{ end }}"
         decoding="async"
         {{ if eq $priority "high" }}fetchpriority="high"{{ end }}
         {{ if and (gt $width 0) (gt $height 0) }}

--- a/layouts/partials/molecules/post_meta_featured_image.html
+++ b/layouts/partials/molecules/post_meta_featured_image.html
@@ -8,6 +8,7 @@
         "page" $page
         "sizes" "(min-width: 800px) 800px, 100vw"
         "widths" (slice 480 800 1200 1600)
+        "priority" "high"
         )
       }}
     </div>


### PR DESCRIPTION
## Summary
Prioritize featured/hero images to improve LCP by aligning existing image preload hints with eager loading and high fetch priority on the corresponding `<img>`.

## Background
Article pages rely on the featured/hero image as the primary above-the-fold visual. Although we already emit `<link rel="preload" as="image">` for these images, the `<img>` elements were still using lazy loading, which can delay LCP under typical network conditions and PJAX navigations. Aligning preload with `loading="eager"` and `fetchpriority="high"` reduces time-to-render and stabilizes LCP.

## What changed
- `layouts/partials/atoms/picture.html`: When `priority` is `"high"`, set `loading="eager"` and `fetchpriority="high"`; keep `loading="lazy"` otherwise.
- `layouts/partials/molecules/post_meta_featured_image.html`: Pass `priority="high"` to the featured image partial so article eyecatch uses the priority path.
- This is consistent with existing hero usage, where `priority="high"` is already provided.
