### PR TITLE
feat(nav): improve hamburger a11y (aria controls + focus-visible)

### DIFF
--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -39,8 +39,32 @@ nav {
 }
 
 nav #menu-bar-btn {
+  /* keep original placement */
   float: left;
-  font-size: 1.5rem;
+  /* reset native button styles */
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  /* align icon like the old div */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 4rem; /* match navbar height */
+  line-height: 4rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+/* Show focus ring only for keyboard navigation */
+nav #menu-bar-btn:focus {
+  outline: none;
+}
+nav #menu-bar-btn:focus-visible {
+  outline: 2px solid var(--pochi-link);
+  outline-offset: 2px;
 }
 
 nav #theme-toggle-switch-container {

--- a/layouts/partials/molecules/nav.html
+++ b/layouts/partials/molecules/nav.html
@@ -10,9 +10,16 @@
           {{ partial "atoms/icon.html" (dict "id" "icon-dark") }}
         </button>
       </div>
-      <div id="menu-bar-btn">
+      <button
+        id="menu-bar-btn"
+        type="button"
+        class="menu-bar-btn"
+        aria-label="メニュー"
+        aria-controls="side-nav"
+        aria-expanded="false"
+      >
         {{ partial "atoms/icon.html" (dict "id" "icon-menu") }}
-      </div>
+      </button>
       <div class="menu-global-nav-container">
         <ul id="menu-global-nav">
           {{ range .Site.Menus.main }}

--- a/layouts/partials/molecules/side_nav.html
+++ b/layouts/partials/molecules/side_nav.html
@@ -2,6 +2,7 @@
   id="side-nav"
   class="menu-global-nav-for-phone-container"
   style="opacity: 0;"
+  aria-hidden="true"
 >
   <div class="side-nav-header">
     <button


### PR DESCRIPTION
## Summary
Improve hamburger menu accessibility and UX without visual regressions.

- Use `<button>` for the trigger (semantic control)
- Add `aria-controls`/`aria-expanded` and keep them in sync on toggle
- Close with `Escape` and return focus to the trigger
- Preserve original layout with button-style reset; show focus only on keyboard via `:focus-visible`

## Why
- Clarifies control/relationship for assistive tech (`aria-controls`)
- Announces current state with `aria-expanded`
- Meets focus visibility expectations for keyboard users (WCAG focus-visible)
- Reduces custom JS/ARIA pitfalls vs. using a `<div role="button">`

## Changes
- HTML: switch trigger to `<button id="menu-bar-btn" aria-controls="side-nav" aria-expanded="false" aria-label="メニュー">`
- JS: sync `aria-expanded` and `#side-nav[aria-hidden]`, add Escape close + focus return
- CSS: reset native button styles; add `:focus-visible` ring; keep placement identical

## Touched Files
- `layouts/partials/molecules/nav.html`
- `layouts/partials/molecules/side_nav.html`
- `assets/js/main.js`
- `assets/scss/components/_nav.scss`

## Verification Steps
1) `npm run serve`
2) Click hamburger: menu opens/closes; overlay click closes
3) Tab to the hamburger: focus ring shows; Space/Enter toggles
4) Inspect attributes: `aria-expanded` toggles true/false; `#side-nav` has `aria-hidden` false/true
5) Press `Escape`: menu closes and focus returns to the hamburger
6) Click a link inside the side nav: menu closes (navigation proceeds)
7) Desktop/mobile widths: no layout shift/regressions

## Notes
- Keeps existing IDs, so current styles remain intact
- Uses `:focus-visible` so rings appear only for keyboard users
- No breaking changes expected
