### PR TITLE
chore: harden supply chain with SHA pinning and Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     ignore:
       - dependency-name: "fuse.js"
       - dependency-name: "mark.js"
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 25
           cache: npm
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: "0.154.1"
           extended: true
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 25
           cache: npm

--- a/.github/workflows/deploy_to_github_page.yml
+++ b/.github/workflows/deploy_to_github_page.yml
@@ -42,12 +42,12 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: example_site
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Get Theme
         run: git submodule update --init --recursive
       - name: Update theme to Latest commit
@@ -58,7 +58,7 @@ jobs:
             --buildDrafts --gc \
             --baseURL ${{ steps.pages.outputs.base_url }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./public
   deploy:
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 25
           cache: npm
@@ -24,7 +24,7 @@ jobs:
       - name: Show Node and npm versions
         run: node -v && npm -v
 
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: "0.154.1"
           extended: true
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: playwright-test-results
           path: |

--- a/.github/workflows/vendor_auto_update.yml
+++ b/.github/workflows/vendor_auto_update.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 25
           cache: npm
@@ -35,7 +35,7 @@ jobs:
         run: npm run vendor:verify
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "chore(vendor): upgrade Fuse/Mark/modern-normalize to latest and sync vendor"
           title: "chore(vendor): upgrade Fuse/Mark/modern-normalize to latest"


### PR DESCRIPTION
## 実装経緯の説明

GitHub Actions のサプライチェーン攻撃対策として、全外部 Action の SHA ピン留めと Dependabot のクールダウン設定を追加した。
タグ参照（例: `@v6`）は攻撃者によって悪意あるコミットに差し替えられるリスクがあるため、完全な SHA で固定することで再現性と安全性を確保する。

## チケット

なし

## 補足

### 主な変更内容

- 全ワークフロー（5ファイル）の外部 Action 18 箇所を commit SHA にピン留め（`pinact v3.9.0` 使用）
- `.github/dependabot.yml` の npm・github-actions エコシステムに `cooldown.default-days: 14` を追加

### 技術的な詳細

- ピン留め対象 Action:
  - `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2
  - `actions/setup-node` → `53b83947a5a98c8d113130e565377fae1a50d02f` # v6.3.0
  - `peaceiris/actions-hugo` → `75d2e84710de30f6ff7268e08f310b60ef14033f` # v3.0.0
  - `actions/upload-artifact` → `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` # v7.0.0
  - `peter-evans/create-pull-request` → `c0f553fe549906ede9cf27b5156039d195d2ece0` # v8.1.0
  - `actions/configure-pages` → `45bfe0192ca1faeb007ade9deae92b16b8254a0d` # v6.0.0
  - `actions/upload-pages-artifact` → `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` # v4.0.0
  - `actions/deploy-pages` → `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` # v5.0.0
  - `dependabot/fetch-metadata` → `ffa630c65fa7e0ecfa0625b5ceda64399aea1b36` # v3.0.0
- Dependabot cooldown 14 日: 新しいリリースが公開されてから 14 日間はアップデート PR を生成しない。悪意ある・不安定なリリースへの即時自動マージを防ぐ

### 確認事項

- CI / E2E ワークフローが正常に動作すること
- Dependabot が次回の週次スキャン時に正しく動作すること
- ピン留めした SHA がそれぞれのタグコメント（`# vX.Y.Z`）と一致していること