### PR TITLE
chore: introduce gitleaks + pre-commit to prevent credential leaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+  '''\.gitleaks\.toml$''',
+  '''go\.sum$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## 実装経緯の説明

ローカルコミット時にシークレット（APIキー・トークン等）が誤ってリポジトリに混入するリスクを機械的にブロックするため、gitleaks + pre-commit を導入した。

## チケット

なし

## 補足

### 主な変更内容

- `.pre-commit-config.yaml` を新規作成 — gitleaks hook (v8.30.1) を設定
- `.gitleaks.toml` を新規作成 — `useDefault = true` でデフォルトルールを有効化、`go.sum` などの false positive になりやすいパスを allowlist に設定

### 技術的な詳細

- `pre-commit install` 済みのため、`git commit` 時に自動で gitleaks が実行される
- シークレットが検出された場合はコミットがブロックされ、exit code 1 で終了する
- `.gitleaks.toml` の `[extend] useDefault = true` により、gitleaks のデフォルトルールセットがすべて有効になる

### 確認事項

- `pre-commit run gitleaks --all-files` でリポジトリ全体に既存の漏洩がないこと
- 意図的に除外すべきファイルがあれば `.gitleaks.toml` の `allowlist` に追記する